### PR TITLE
#1505 Restrict IA upload to Word files only

### DIFF
--- a/src/packages/draftComponents/Form/FileUpload.vue
+++ b/src/packages/draftComponents/Form/FileUpload.vue
@@ -80,10 +80,10 @@ export default {
         };
       },
     },
-    type: {
+    types: {
       type: String,
       required: false,
-      default: 'other',
+      default: '.pdf,.docx,.doc,.odt,.txt,.fodt',
     },
   },
   data() {
@@ -109,10 +109,7 @@ export default {
       },
     },
     fileExtensions() {
-      if (this.$props.type && this.$props.type === 'ia') {
-        return '.doc,.docx';
-      }
-      return '.pdf,.docx,.doc,.odt,.txt,.fodt';
+      return this.$props.types;
     },
   },
   async mounted () {
@@ -149,13 +146,11 @@ export default {
       }
       const fileExtension = parts.pop();
 
-      if (this.$props.type && this.$props.type === 'other') {
-        if (this.acceptableExtensions.includes(fileExtension)){
+      if (this.$props.types) {
+        const providedTypes = this.$props.types.split(',');
+        if (providedTypes.includes(`.${fileExtension}`)) {
           return true;
         }
-      }
-      if (this.$props.type && this.$props.type === 'ia' && (fileExtension === 'doc' || fileExtension === 'docx')) {
-        return true;
       }
       return false;
     },

--- a/src/packages/draftComponents/Form/FileUpload.vue
+++ b/src/packages/draftComponents/Form/FileUpload.vue
@@ -38,6 +38,7 @@
       :id="id"
       ref="file"
       type="file"
+      :accept="fileExtensions"
       class="govuk-file-upload"
       :class="{'govuk-input--error': hasError}"
       @change="fileSelected"
@@ -79,6 +80,11 @@ export default {
         };
       },
     },
+    type: {
+      type: String,
+      required: false,
+      default: 'other',
+    },
   },
   data() {
     return {
@@ -101,6 +107,12 @@ export default {
           this.$emit('input', val);
         }
       },
+    },
+    fileExtensions() {
+      if (this.$props.type && this.$props.type === 'ia') {
+        return '.doc,.docx';
+      }
+      return '.pdf,.docx,.doc,.odt,.txt,.fodt';
     },
   },
   async mounted () {
@@ -132,15 +144,19 @@ export default {
     },
     validFileExtension(originalName){
       const parts = originalName.split('.');
-
       if (parts.length < 2){
         return false;
       }
+      const fileExtension = parts.pop();
 
-      if (this.acceptableExtensions.includes(parts.pop())){
+      if (this.$props.type && this.$props.type === 'other') {
+        if (this.acceptableExtensions.includes(fileExtension)){
+          return true;
+        }
+      }
+      if (this.$props.type && this.$props.type === 'ia' && (fileExtension === 'doc' || fileExtension === 'docx')) {
         return true;
       }
-
       return false;
     },
     fileIsEmpty(size){


### PR DESCRIPTION
Users should be able to upload only .doc/.docx files for IAs on the Exercise Downloads page:

![Screenshot 2021-10-15 at 10 46 15](https://user-images.githubusercontent.com/40855898/137468703-fc8c2e09-f5bf-4d0a-9c74-db2603294174.png)

Other downloads should not be affected:

![Screenshot 2021-10-15 at 10 45 24](https://user-images.githubusercontent.com/40855898/137468678-1aa7ff8c-96db-4c2c-8ee0-0a5bb5cdd441.png)

