### PR TITLE
Table handle no data

### DIFF
--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -147,6 +147,12 @@
         </tr>
       </tbody>
     </table>
+    <div 
+      class="govuk-body govuk-!-margin-top-4"
+      v-else
+      >
+      No results found
+    </div>
     <nav
       v-if="showPaging"
       class="moj-pagination"

--- a/tests/unit/components/Table/Table.spec.js
+++ b/tests/unit/components/Table/Table.spec.js
@@ -1,0 +1,40 @@
+import { createTestSubject } from '../../helpers';
+
+import Table from '@/components/Table/Table';
+
+describe('components/Banner', () => {
+  describe('props', () => {
+    let prop;
+    describe('message', () => {
+      beforeEach(() => {
+        prop = Table.props.columns;
+      });
+      it('is a string', () => {
+        expect(prop.type()).toBeArray();
+      });
+    });
+  });
+  
+  describe('component instance', () => {
+    let wrapper;
+      beforeEach(() => {
+      wrapper = createTestSubject(Table, {
+        mocks: {},
+        stubs: [],
+        propsData: {
+          columns: [],
+          data: [],
+          dataKey: 'mockDataKey',
+        },
+      });
+    });
+      
+    it('renders the component', () => {
+      expect(wrapper.exists()).toBe(true);
+    });
+    
+    it('displays message when data is empty', () => {
+      expect(wrapper.find('div .govuk-body').text()).toBe('No results found');
+    });
+  });
+});


### PR DESCRIPTION
Part of standardising tables across the platform, now empty tables display a message, however this shows while loading and also potentially if there is an error within the props.

i wrote some tests for this and it has led me to consider;
- can we get the tests running as part of the integration?
- Can we consider adding an error handler of some kind to this component, worried that we now may have the opposite issue this is solving.