### PR TITLE
Bugfix. Search clear button doesn't update value

### DIFF
--- a/src/packages/components/Table/Search.vue
+++ b/src/packages/components/Table/Search.vue
@@ -13,7 +13,6 @@
           type="search"
           aria-describedby="search-hint"
           :placeholder="placeholder"
-          @keyup="startSearch"
         >
       </div>
     </form>
@@ -33,6 +32,11 @@ export default {
     return {
       search: '',
     };
+  },
+  watch: {
+    search() {
+      this.startSearch();
+    },
   },
   methods: {
     startSearch() {


### PR DESCRIPTION
**Bug:** Search clear button doesn't update the search value.

**Solution:** Add a watch listener to update search value if there're any changes.

**Demo:**

- Before

    https://user-images.githubusercontent.com/79906532/174791665-211ab479-2f6c-4c71-803d-f05280b54d5d.mov

- After

    https://user-images.githubusercontent.com/79906532/174791696-7f50d5ed-e9e6-442a-9c2e-bbd59cc08f64.mov

