### PR TITLE
Add qualification constants and filters

### DIFF
--- a/src/packages/filters/filters.js
+++ b/src/packages/filters/filters.js
@@ -405,8 +405,8 @@ const lookup = (value) => {
     lookup[QUALIFYING_TEST.TYPE.CRITICAL_ANALYSIS] = 'Critical analysis';
     lookup[QUALIFYING_TEST.TYPE.SITUATIONAL_JUDGEMENT] = 'Situational judgement';
 
-    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_1] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
-    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_2] = 'Called to the Bar prior to 1 January 2002';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.TRANSFERRED] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.CALLED_PRE_2002] = 'Called to the Bar prior to 1 January 2002';
     lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OTHER] = 'Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board';
 
     // TODO add the missing ones from CONSTANTS

--- a/src/packages/filters/filters.js
+++ b/src/packages/filters/filters.js
@@ -1,4 +1,4 @@
-import { APPLICATION_STATUS, QUALIFYING_TEST } from '../helpers/constants';
+import { APPLICATION_STATUS, QUALIFYING_TEST, NOT_COMPLETE_PUPILLAGE_REASONS } from '../helpers/constants';
 
 const formatDate = (value, type) => {
   if (value !== null && value !== undefined) {
@@ -184,6 +184,7 @@ const lookup = (value) => {
       'employment-appeals-tribunal': 'Employment Appeals Tribunal',
       'employment-tribunal': 'Employment Tribunal',
       'england-wales': 'England and Wales',
+      'true': 'Yes',
       'false': 'No',
       'family': 'Family',
       'fee-paid': 'Fee paid',
@@ -403,6 +404,11 @@ const lookup = (value) => {
     lookup[QUALIFYING_TEST.TYPE.SCENARIO] = 'Scenario';
     lookup[QUALIFYING_TEST.TYPE.CRITICAL_ANALYSIS] = 'Critical analysis';
     lookup[QUALIFYING_TEST.TYPE.SITUATIONAL_JUDGEMENT] = 'Situational judgement';
+
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_1] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_2] = 'Called to the Bar prior to 1 January 2002';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OTHER] = 'Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board';
+
     // TODO add the missing ones from CONSTANTS
 
     // RETURN - END of LOOKUP

--- a/src/packages/helpers/constants.js
+++ b/src/packages/helpers/constants.js
@@ -95,6 +95,12 @@ const DEFAULT = {
   NO: 'No',
 };
 
+const NOT_COMPLETE_PUPILLAGE_REASONS = {
+  OPTION_1: 'reason-not-completed-pupillage-1',
+  OPTION_2: 'reason-not-completed-pupillage-2',
+  OTHER: 'reason-not-completed-pupillage-other',
+};
+
 export {
   STATUS,
   EXERCISE_STAGE,
@@ -102,5 +108,6 @@ export {
   SHORTLISTING,
   QUALIFYING_TEST,
   QUALIFYING_TEST_RESPONSE,
-  DEFAULT
+  DEFAULT,
+  NOT_COMPLETE_PUPILLAGE_REASONS
 };

--- a/src/packages/helpers/constants.js
+++ b/src/packages/helpers/constants.js
@@ -96,9 +96,9 @@ const DEFAULT = {
 };
 
 const NOT_COMPLETE_PUPILLAGE_REASONS = {
-  OPTION_1: 'reason-not-completed-pupillage-1',
-  OPTION_2: 'reason-not-completed-pupillage-2',
-  OTHER: 'reason-not-completed-pupillage-other',
+  TRANSFERRED: 'transferred ',
+  CALLED_PRE_2002: 'called-pre-2002',
+  OTHER: 'other',
 };
 
 export {


### PR DESCRIPTION
Add the reasons of not completing pupillage to constants and filters.

Note: This PR is related to [admin #926 Barrister eligibility](https://github.com/jac-uk/admin/pull/1745) and [apply #926 Barrister eligibility](https://github.com/jac-uk/apply/pull/927).