### PR TITLE
#90 Bugfix: Page size should be an optional prop

### DIFF
--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -383,6 +383,7 @@ export default {
       return items;
     },
     showNext() {
+      if (!this.pageSize) return false; // hide `Next` button if page size is 0
       if (this.total) {
         const length = Math.ceil(this.total / this.pageSize);
         return this.page < length - 1;


### PR DESCRIPTION
Show no `Next` page button when using the `Table` component without passing `page-size` as a prop. 