### PR TITLE
Added check to ensure integers can't have trailing decimal places.

### DIFF
--- a/src/packages/filters/filters.js
+++ b/src/packages/filters/filters.js
@@ -50,13 +50,26 @@ const formatNumber = (originalValue, decimalPlaces) => {
   let transformedValue = null;
   if (originalValue) {
     if (decimalPlaces > 0) {
-      transformedValue = Number(originalValue).toFixed(decimalPlaces);
+      if (isInt(originalValue)) {
+        transformedValue = originalValue;
+      }
+      else {
+        transformedValue = Number(originalValue).toFixed(decimalPlaces);
+      }
     } else {
       transformedValue = parseInt(originalValue);
     }
     return transformedValue.toLocaleString('en-GB');
   }
   return originalValue;
+};
+
+const isInt = (value) => {
+  if (isNaN(value)) {
+    return false;
+  }
+  var x = parseFloat(value);
+  return (x | 0) === x;
 };
 
 const formatNIN = (value) => {
@@ -437,5 +450,6 @@ export {
   toHumanCase,
   toYesNo,
   showAlternative,
-  lookup
+  lookup,
+  isInt
 };

--- a/tests/unit/filters/formatNumber.spec.js
+++ b/tests/unit/filters/formatNumber.spec.js
@@ -6,9 +6,12 @@ describe('formatNumber', () => {
     expect(formatNumber(1000)).toEqual('1,000');
     expect(formatNumber(100000)).toEqual('100,000');
     expect(formatNumber(1000000)).toEqual('1,000,000');
+    expect(formatNumber('1000000')).toEqual('1,000,000');
     expect(formatNumber(null)).toEqual(null);
     expect(formatNumber(undefined)).toEqual(undefined);
     expect(formatNumber(0.1274, 2)).toEqual('0.13');
     expect(formatNumber(1001.1274, 2)).toEqual('1001.13');
+    expect(formatNumber('1001.1274', 2)).toEqual('1001.13');
+    expect(formatNumber(1001, 2)).toEqual('1,001');
   });
 });

--- a/tests/unit/filters/isInt.spec.js
+++ b/tests/unit/filters/isInt.spec.js
@@ -1,0 +1,12 @@
+import { isInt } from '@/filters/filters';
+
+describe('isInt', () => {
+  it('isInt', () => {
+    expect(isInt(100)).toEqual(true);
+    expect(isInt(1000.9)).toEqual(false);
+    expect(isInt(' 1 ')).toEqual(true);
+    expect(isInt('0.123')).toEqual(false);
+    expect(isInt(null)).toEqual(false);
+    expect(isInt(undefined)).toEqual(false);
+  });
+});


### PR DESCRIPTION
If a whole number is passed to the formatNumber helper (with 2 dp specified) we want it to be returned as a formatted whole number, ie without '.00' at the end.