### PR TITLE
Trim whitespace for TextField component

### DIFF
--- a/src/packages/draftComponents/Form/TextField.vue
+++ b/src/packages/draftComponents/Form/TextField.vue
@@ -80,6 +80,7 @@ export default {
         return this.modelValue;
       },
       set(val) {
+        val = val.trim();
         switch (this.type) {
         case 'number':
           //this.$emit('input', val ? parseFloat(val) : '');


### PR DESCRIPTION
On the platform candidates are adding leading spaces to text boxes so they appear at the top of lists of candidates in exercises and other areas in the platform e.g Merit Lists, Sift Packs etc.

When candidates enter data on the apply side leading spaces need to be removed before saved and or ignore leading spaces in sorting order.

The fix trims all leading and trailing spaces for the TextField component.