### PR TITLE
Fix validation errors

### DIFF
--- a/src/packages/draftComponents/Form/FormField.vue
+++ b/src/packages/draftComponents/Form/FormField.vue
@@ -114,7 +114,9 @@ export default {
 
         if (this.type) {
           if (this.type === 'email') {
-            value = value.trim().toLowerCase();
+            if (value) {
+              value = value.trim().toLowerCase();
+            }
             this.text = value;
             if (!this.regex.email.test(value)) {
               this.setError(`Enter a valid email address for ${this.label}`);

--- a/src/packages/draftComponents/Form/TextField.vue
+++ b/src/packages/draftComponents/Form/TextField.vue
@@ -3,7 +3,6 @@
     class="govuk-form-group"
     :class="{ 'govuk-form-group--error': hasError }"
   >
-
     <label
       :for="id"
       class="govuk-heading-m govuk-!-margin-bottom-2"
@@ -27,7 +26,7 @@
       :class="[inputClass, { 'govuk-input--error': hasError }]"
       :type="fieldType"
       :autocomplete="localAutocomplete"
-      @change="validate"
+      @input="validate"
     >
   </div>
 </template>
@@ -53,10 +52,6 @@ export default {
       default: '',
       type: [String, Number],
     },
-    // value: {
-    //   default: '',
-    //   type: [String, Number],
-    // },
     type: {
       default: 'text',
       type: String,
@@ -66,27 +61,19 @@ export default {
       type: String,
     },
   },
-
-  //emits: ['input'],
   emits: ['update:modelValue'],
   computed: {
     value: {
-
-      // get: () => props.modelValue,
-      // set: (value) => emit('update:modelValue', value)
-
       get() {
-        //return this.value;
         return this.modelValue;
       },
       set(val) {
+        val = val.trim();
         switch (this.type) {
         case 'number':
-          //this.$emit('input', val ? parseFloat(val) : '');
           this.$emit('update:modelValue', val ? parseFloat(val) : '');
           break;
         default:
-          //this.$emit('input', val);
           this.$emit('update:modelValue', val);
         }
       },

--- a/src/packages/draftComponents/Form/TextareaInput.vue
+++ b/src/packages/draftComponents/Form/TextareaInput.vue
@@ -21,10 +21,10 @@
     />
     <textarea
       :id="id"
-      v-model="text"
+      v-model="value"
       class="govuk-textarea"
       :rows="rows"
-      @change="validate"
+      @input="validate"
     />
   </div>
 </template>
@@ -55,7 +55,7 @@ export default {
   },
   emits: ['update:modelValue'],
   computed: {
-    text: {
+    value: {
       get() {
         return this.modelValue;
       },


### PR DESCRIPTION
Use 'value' as the name of the computed prop for textarea. This was using 'text' but the FormField component references 'value' so this wasnt getting picked up.
Use @input instead of @change to detect changes on input.
Check 'value' is not null/undefined before trimming and changing case of string.

Note that there are a couple of fixes to feature/vue3-upgrade (in Admin) which should be deployed when this branch is merged with main for testing.