### PR TITLE
Bugfix/ActionButton click event

### DIFF
--- a/src/packages/draftComponents/ActionButton.vue
+++ b/src/packages/draftComponents/ActionButton.vue
@@ -46,6 +46,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    click: {
+      type: Function,
+      default: () => {},
+    },
   },
   data: () => ({
     isLoading: false,
@@ -66,7 +70,7 @@ export default {
     async handleClick(e) {
       try {
         this.isLoading = true;
-        const result = await this.$attrs.click(e);
+        const result = await this.click(e);
         if (result) {
           this.resetDelayed('isSuccess');
         } else {


### PR DESCRIPTION
Fix the error `this.$attrs.click is not a function` due to the upgrade to Vue3.