### PR TITLE
Bugfix/Rename prop in ActionButton

### DIFF
--- a/src/packages/draftComponents/ActionButton.vue
+++ b/src/packages/draftComponents/ActionButton.vue
@@ -46,7 +46,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    click: {
+    action: {
       type: Function,
       default: () => {},
     },
@@ -70,7 +70,7 @@ export default {
     async handleClick(e) {
       try {
         this.isLoading = true;
-        const result = await this.click(e);
+        const result = await this.action(e);
         if (result) {
           this.resetDelayed('isSuccess');
         } else {


### PR DESCRIPTION
Change prop `click` to `action`. 

Note: ensure to pass a function to this prop when using `ActionButton`.