### PR TITLE
Admin #2089 Save file improvements

### DIFF
--- a/src/packages/helpers/export.js
+++ b/src/packages/helpers/export.js
@@ -1,7 +1,7 @@
 import XLSXPopulate from 'xlsx-populate';
-import { save } from 'save-file';
+import { save, saveSync } from 'save-file';
 
-const downloadXLSX = async (data, options) => {
+const downloadXLSX = async (data, options, isSync = false) => {
   const workbook = await XLSXPopulate.fromBlankAsync();
 
   workbook.property({
@@ -24,7 +24,11 @@ const downloadXLSX = async (data, options) => {
   sheet.freezePanes(0, 1);
 
   const blob = await workbook.outputAsync();
-  await save(blob, options.fileName);
+  if (isSync) {
+    saveSync(blob, options.fileName);
+  } else {
+    save(blob, options.fileName);
+  }
 };
 
 export {

--- a/src/packages/helpers/export.js
+++ b/src/packages/helpers/export.js
@@ -1,7 +1,7 @@
 import XLSXPopulate from 'xlsx-populate';
-import { save, saveSync } from 'save-file';
+import { saveSync } from 'save-file';
 
-const downloadXLSX = async (data, options, isSync = false) => {
+const downloadXLSX = async (data, options) => {
   const workbook = await XLSXPopulate.fromBlankAsync();
 
   workbook.property({
@@ -24,11 +24,7 @@ const downloadXLSX = async (data, options, isSync = false) => {
   sheet.freezePanes(0, 1);
 
   const blob = await workbook.outputAsync();
-  if (isSync) {
-    saveSync(blob, options.fileName);
-  } else {
-    save(blob, options.fileName);
-  }
+  saveSync(blob, options.fileName);
 };
 
 export {


### PR DESCRIPTION
## What's included?
Use `saveSync` in `downloadXLSX` function to allow downloading multiple files without re-focusing the tab.

### Before
If there are two files that need to download, the browser requires the user to move the focus out of the tab and back in order to load the next file. This is because we use the `save` function from the third-party package `save-file`.

https://github.com/jac-uk/jac-kit/assets/79906532/9b27162e-b3c0-4fea-9243-4ea441918d5c

https://github.com/jac-uk/jac-kit/assets/79906532/88cd839d-9977-4d68-ad70-a2b0bf247536

### After

https://github.com/jac-uk/jac-kit/assets/79906532/50b616d8-7cc0-42af-991c-cb24d49af122

https://github.com/jac-uk/jac-kit/assets/79906532/b97ef6c2-e21e-4667-8fd0-907c72cfefc7


