### PR TITLE
Feature/dp 875 search improvements

### DIFF
--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -709,6 +709,14 @@ export default {
           }
         }
       }
+      // If search is used then use numbered pagination
+      if (this.searchTerm.length >= 3) {
+        this.currentPageItemType = 'number';
+      }
+      else {
+        // Revert to original value
+        this.currentPageItemType = this.pageItemType;
+      }
       if (!this.defaultState.searchMap || (this.searchTerm.length === 0 || this.searchTerm.length >= 3)) {
         if (this.currentPageItemType === 'number') {
           this.page = 0; // reset current page to first page when using search function

--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -3,7 +3,7 @@
     class="jac-table"
     :class="{ 'sticky-headers-table': sticky }"
   >
-    <div class="govuk-grid-row">
+    <div class="govuk-grid-row govuk-!-margin-bottom-4">
       <div
         v-if="hasSearch"
         class="govuk-grid-column-one-half"
@@ -73,11 +73,11 @@
     </SidePanel>
     <LoadingMessage
       v-if="loading"
-      class="loading"
+      class="loading govuk-!-margin-bottom-2"
     />
     <table
       v-if="hasData"
-      class="govuk-table govuk-!-margin-top-2"
+      class="govuk-table"
     >
       <thead class="govuk-table__head">
         <slot name="header" />

--- a/src/packages/package-lock.json
+++ b/src/packages/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jac-uk/jac-kit",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jac-uk/jac-kit",
-      "version": "3.0.18",
+      "version": "3.0.19",
       "dependencies": {
         "@ckeditor/ckeditor5-build-classic": "^38.1.0",
         "@ckeditor/ckeditor5-vue": "^5.1.0",

--- a/src/packages/package.json
+++ b/src/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jac-uk/jac-kit",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
When performing a (table) search if a valid search term has been passed in then override pagination to use the 'number' format. If the search term is removed or invalid then revert it back to whatever the initial value was.