### PR TITLE
Update Table component to support dynamic page sizes

### DIFF
--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -341,6 +341,7 @@ export default {
   data() {
     return {
       currentPageItemType: this.pageItemType,
+      currentPageSize: this.pageSize,
       currentLetter: this.getInitCurrentLetter(this.pageItemType),
       loading: !this.localData,
       searchTerm: null,
@@ -355,9 +356,6 @@ export default {
     };
   },
   computed: {
-    currentPageSize() {
-      return this.pageSize;
-    },
     defaultState() {
       const state = {};
       if (this.currentPageSize) {
@@ -485,6 +483,7 @@ export default {
       },
     },
     pageSize() {
+      this.currentPageSize = this.pageSize;
       this.changeTableState(ACTIONS.PAGE_SIZE, this.currentState);
     },
   },


### PR DESCRIPTION
Fixes a bug where work on two separate features both added new property with the same name `currentPageSize`.

Here we fix the `currentPageSize` field to work for both features, making it a local data variable rather than a read-only computed.