### PR TITLE
Admin #2120

### DIFF
--- a/src/packages/draftComponents/Form/ErrorSummary.vue
+++ b/src/packages/draftComponents/Form/ErrorSummary.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="errors.length"
+    id="error-summary"
     class="govuk-error-summary"
     aria-labelledby="error-summary-title"
     role="alert"

--- a/src/packages/draftComponents/Form/Form.vue
+++ b/src/packages/draftComponents/Form/Form.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script>
+import { nextTick } from 'vue';
 export default {
   data() {
     return {
@@ -29,12 +30,13 @@ export default {
         }
       }
       if (this.errors.length) {
-        this.scrollToErrorSummary();
+        nextTick(() => {  // Use nextTick as the error summary isn't displayed until after render
+          this.scrollToErrorSummary();
+        });
       }
     },
     scrollToErrorSummary(){
-      //This is just scrolling to top of page
-      this.$el.scrollIntoView();
+      document.getElementById('error-summary').scrollIntoView(); 
     },
     isValid() {
       return this.errors.length === 0;

--- a/src/packages/draftComponents/Form/FormField.vue
+++ b/src/packages/draftComponents/Form/FormField.vue
@@ -149,7 +149,7 @@ export default {
 
           const isNull = (value === null);
           const isUndefined = (value === undefined);
-          const isEmpty = (value !== null && value.length === 0);
+          const isEmpty = (value !== null && Array.isArray(value) && value.length === 0);
           const isEmptyString = (typeof value === 'string' && value.replace(/\s/g, '').length === 0);
 
           if (this.required && ((isNull || isUndefined || isEmpty) || isEmptyString)) {


### PR DESCRIPTION
Added an id to the error summary.
Now scrollIntoView is called on a different element preventing the sideways shift in the display when the error displays. Also fixed a minor error in the FormField.