### PR TITLE
Ensure top level class has high z-index due to stacking order issue.

### DIFF
--- a/src/packages/draftComponents/TabMenu.vue
+++ b/src/packages/draftComponents/TabMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tab-menu">
+  <nav class="tab-menu">
     <ul class="tabs govuk-header__navigation user-menu">
       <li
         v-for="(tab, index) in tabs"
@@ -50,7 +50,7 @@
         </template>
       </li>
     </ul>
-  </div>
+  </nav>
 </template>
 
 <script>
@@ -115,6 +115,10 @@ export default {
 </script>
 
 <style scoped>
+.tab-menu {
+  position: relative; /* Create a new stacking context */
+  z-index: 1000; /* Ensure it has a high z-index */
+}
 
 .tabs {
   list-style-type: none;


### PR DESCRIPTION
The sub menu sits beneath the Add Panellist button on the Panellists page. Set a high z-index for the top level class for the tabs menu to fix this.