### PR TITLE
Table. Support extra rows

### DIFF
--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -143,40 +143,49 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <tr
+          <template
             v-for="(row, index) in data"
             :key="row[dataKey]"
-            class="govuk-table__row govuk-!-padding-left-2 govuk-!-padding-right-2"
-            :class="{ clickable: row.rowLink }"
-            @click.stop="row.rowLink ? navigate(row.rowLink) : null"
           >
-            <td
-              v-if="multiSelect"
-              class="govuk-table__cell govuk-!-padding-top-0"
+            <tr
+              class="govuk-table__row govuk-!-padding-left-2 govuk-!-padding-right-2"
+              :class="{ clickable: row.rowLink }"
+              @click.stop="row.rowLink ? navigate(row.rowLink) : null"
             >
-              <div class="govuk-checkboxes govuk-checkboxes--small">
-                <div class="govuk-checkboxes__item">
-                  <input
-                    :id="`item-${row[dataKey]}`"
-                    v-model="selectedItems"
-                    :value="row[dataKey]"
-                    class="govuk-checkboxes__input"
-                    type="checkbox"
-                    @click.stop
-                  >
-                  <label
-                    class="govuk-label govuk-checkboxes__label"
-                    :for="`item-${row[dataKey]}`"
-                  />
+              <td
+                v-if="multiSelect"
+                class="govuk-table__cell govuk-!-padding-top-0"
+              >
+                <div class="govuk-checkboxes govuk-checkboxes--small">
+                  <div class="govuk-checkboxes__item">
+                    <input
+                      :id="`item-${row[dataKey]}`"
+                      v-model="selectedItems"
+                      :value="row[dataKey]"
+                      class="govuk-checkboxes__input"
+                      type="checkbox"
+                      @click.stop
+                    >
+                    <label
+                      class="govuk-label govuk-checkboxes__label"
+                      :for="`item-${row[dataKey]}`"
+                    />
+                  </div>
                 </div>
-              </div>
-            </td>
+              </td>
+              <slot
+                name="row"
+                :row="row"
+                :index="index"
+              />
+            </tr>
             <slot
-              name="row"
+              name="extra-row"
               :row="row"
               :index="index"
             />
-          </tr>
+          </template>
+
           <slot name="footer" />
         </tbody>
       </table>
@@ -711,7 +720,6 @@ export default {
           }
           break;
         case 'radio':
-        case 'option':
           if (this.filterValues[filter.field]) {
             const value = this.filterValues[filter.field];
             // Ensure if empty option is selected the 'where' clause is skipped
@@ -939,6 +947,7 @@ export default {
         cursor: pointer;
       }
     }
+
     /* Get the JAC-KIT colour from Warren for header-link */
     tr:nth-child(2) > th {
       position: sticky;
@@ -974,4 +983,5 @@ export default {
       -o-text-overflow: ellipsis;  // for Opera 9 & 10
     }
   }
+
 </style>

--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -720,6 +720,7 @@ export default {
           }
           break;
         case 'radio':
+        case 'option':
           if (this.filterValues[filter.field]) {
             const value = this.filterValues[filter.field];
             // Ensure if empty option is selected the 'where' clause is skipped

--- a/src/packages/components/Table/Table.vue
+++ b/src/packages/components/Table/Table.vue
@@ -905,10 +905,10 @@ export default {
     table {
       display: block;
       overflow-x: auto;
-      overflow-y: auto;
+      overflow-y: hidden;
       scroll-behavior: smooth;
       max-width: 100%;
-      max-height: 80vh;
+      // max-height: 80vh;
       margin: 0 !important;
       border-spacing: 0;
       table-layout: fixed;
@@ -921,7 +921,7 @@ export default {
     }
     th,
     td {
-        border: 1px solid #f3f2f1;
+        border: 1px solid #b1b4b6;
         vertical-align: middle;
         white-space: nowrap;
         &.v-top {
@@ -940,15 +940,13 @@ export default {
       top: 0;
       background-color:#f3f2f1;
       z-index: 2;
-      border: 0;
-      padding-left: 20px;
+      border-top: 0;
+      // padding-left: 20px;
       &.expandable {
         text-decoration: underline;
         cursor: pointer;
       }
     }
-
-    /* Get the JAC-KIT colour from Warren for header-link */
     tr:nth-child(2) > th {
       position: sticky;
       top: 46px;

--- a/src/packages/components/Table/tableQuery.js
+++ b/src/packages/components/Table/tableQuery.js
@@ -1,6 +1,6 @@
 import vuexfireSerialize from '../../helpers/vuexfireSerialize';
 import { formatSearchTerm } from '../../helpers/search';
-import { query, where, orderBy as firesoterOrderBy, limit, startAfter as firestoreStarAfter, endBefore as firestoreEndBefore, documentId, limitToLast, getDocs } from "firebase/firestore";
+import { query, where, orderBy as firestoreOrderBy, limit, startAfter as firestoreStarAfter, endBefore as firestoreEndBefore, documentId, limitToLast, getDocs } from "firebase/firestore";
 
 const search = (searchValue) => {
   let returnValue = null;
@@ -84,7 +84,7 @@ const filteredQuery = (ref, params) => {
           queryRef,
           where(params.search[0], '>=', returnSearch.value1),
           where(params.search[0], '<', returnSearch.value2),
-         firesoterOrderBy(params.search[0], 'asc'),
+          firestoreOrderBy(params.search[0], 'asc'),
         );
         orderBy = [params.search[0]];
       }


### PR DESCRIPTION
In the `Table` component we now have a slot for adding extra row(s) after each row.

Used in the merit list to make an accordion-style table:
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/1ecc27fa-5673-44d6-9e39-6bcaf56ef24b">

Plus some tweaks for sticky headers and a typo fix from `firesoterOrderBy` to `firestoreOrderBy` 😄 